### PR TITLE
Use package realpath instead of path

### DIFF
--- a/colcon_lcov_result/task/lcov.py
+++ b/colcon_lcov_result/task/lcov.py
@@ -60,7 +60,7 @@ class LcovCaptureTask(TaskExtensionPoint):
 
         cmd = [LCOV_EXECUTABLE,
                '--gcov-tool', GCOV_EXECUTABLE,
-               '--base-directory', str(pkg.path),
+               '--base-directory', str(pkg.realpath),
                '--capture',
                '--directory', str(pkg_build_folder),
                '--output-file', str(output_file),
@@ -70,7 +70,7 @@ class LcovCaptureTask(TaskExtensionPoint):
         rc = await check_call(
             self.context,
             cmd,
-            cwd=str(pkg.path)
+            cwd=str(pkg.realpath)
         )
 
         if rc.returncode == 0 and args.verbose:
@@ -117,7 +117,7 @@ class LcovZeroCountersTask(TaskExtensionPoint):
 
         cmd = [LCOV_EXECUTABLE,
                '--gcov-tool', GCOV_EXECUTABLE,
-               '--base-directory', str(pkg.path),
+               '--base-directory', str(pkg.realpath),
                '--zerocounters',
                '--quiet',
                '--directory', str(pkg_build_folder)]
@@ -125,7 +125,7 @@ class LcovZeroCountersTask(TaskExtensionPoint):
         await check_call(
             self.context,
             cmd,
-            cwd=str(pkg.path)
+            cwd=str(pkg.realpath)
         )
 
 


### PR DESCRIPTION
- As of colcon-core 0.5.2 'path' is a relative path
instead of an absolute path
- lcov's base-directory argument expects an absolute
path in colcon lcov-results current implementation

## How to test
1. Clone this repository and checkout this branch
2. Install `colcon` and extensions in a virtual environment (to prevent messing up your current environment)
    ```
   $  cd ~
   $ python3 -m venv colcon-venv
   $ source colcon-venv/bin/activate
   $ pip3 install colcon-common-extensions
   $ cd /path/to/colcon-lcov-result
   $ pip3 install .  # Installs colcon-lcov-result
   ```
3. Follow the workflow in the README.rst to generate results (https://github.com/colcon/colcon-lcov-result/tree/master#usage)

## References
- Closes #10 