### PR TITLE
Add missing space in help message

### DIFF
--- a/colcon_lcov_result/verb/lcov_result.py
+++ b/colcon_lcov_result/verb/lcov_result.py
@@ -65,7 +65,7 @@ class LcovResultVerb(VerbExtensionPoint):
         parser.add_argument(
             '--initial',
             action='store_true',
-            help='Generate baseline (zero) coverage. This option is meant to be used before'
+            help='Generate baseline (zero) coverage. This option is meant to be used before '
                  'running `colcon test`'
         )
         parser.add_argument(


### PR DESCRIPTION
Simple fix.

Before:

```
  --initial             Generate baseline (zero) coverage. This option is
                        meant to be used beforerunning `colcon test`
```

After:

```
  --initial             Generate baseline (zero) coverage. This option is
                        meant to be used before running `colcon test`
```