### PR TITLE
Add support for ros.catkin packages

### DIFF
--- a/colcon_lcov_result/verb/lcov_result.py
+++ b/colcon_lcov_result/verb/lcov_result.py
@@ -177,7 +177,7 @@ class LcovResultVerb(VerbExtensionPoint):
             if not decorator.selected:
                 continue
             pkg = decorator.descriptor
-            if pkg.type in ['ros.ament_cmake', 'ros.cmake', 'cmake']:
+            if pkg.type in ['ros.ament_cmake', 'ros.catkin', 'ros.cmake', 'cmake']:
                 gcc_pkgs.append(pkg)
             else:
                 logger.info('Specified package {} is not a gcc package. Not '


### PR DESCRIPTION
Fixes #18.

Tested locally with a Noetic ws (`ros_control` & `ros_controllers`). Works as expected.

As a sanity check, I created a quick Foxy ws with the same-ish packages (`ros2_control` & `ros2_controllers`), and they match up nicely.