### PR TITLE
Match name in stdeb config to package name.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,4 @@
-[colcon-coverage-result]
+[colcon-lcov-result]
 Depends3: python3-colcon-core
 Suite: xenial bionic stretch buster
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
I'm not sure whether this creates problems releasing with publish-python
but the mismatched names caused stdeb to use defaults rather than the
configured values for me using ros_release_python.