### PR TITLE
Add Ubuntu Focal (20.04) distribution to stdeb.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,4 @@
 [colcon-coverage-result]
 Depends3: python3-colcon-core
-Suite: xenial bionic stretch buster
+Suite: xenial bionic focal stretch buster
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
When using with publish-python this configuration value is not used so I think that accepting this PR is somewhat discretionary but it would put the stdeb.cfg and publish-python.yaml in sync.