### PR TITLE
Add schedule to run CI nightly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - master
+  schedule:
+    # Run automatically every day
+    - cron: "0 0 * * *"
 
 jobs:
   test:


### PR DESCRIPTION
Part of #12, but there are currently no end-to-end tests.