### PR TITLE
Update release platforms

### DIFF
--- a/publish-python.yaml
+++ b/publish-python.yaml
@@ -8,8 +8,9 @@ artifacts:
         config:
           repository: dirk-thomas/colcon
           distributions:
-            - ubuntu:xenial
             - ubuntu:bionic
             - ubuntu:focal
+            - ubuntu:jammy
             - debian:stretch
             - debian:buster
+            - debian:bullseye


### PR DESCRIPTION
Remove Xenial, add Jammy, add Bullseye.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>