### PR TITLE
Use extras_require[test] instead of tests_require

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,10 @@ python_requires = >=3.6
 install_requires =
     colcon-core>=0.5.6
 packages = find:
-tests_require =
+zip_safe = true
+
+[options.extras_require]
+tests =
     flake8>=3.6.0
     flake8-blind-except
     flake8-builtins
@@ -42,7 +45,6 @@ tests_require =
     pytest
     pytest-cov
     scspell3k>=2.2
-zip_safe = true
 
 [options.package_data]
 colcon_lcov_result.verb.configuration = lcovrc


### PR DESCRIPTION
This replaces `tests_require` with a pattern that seems to have popped up since pypa/setuptools#931 and pypa/setuptools#1684. It allows test dependencies to be installed by adding `[test]` to the end of the package name.