### PR TITLE
Support Additional lcov_result Args

### DIFF
--- a/colcon_lcov_result/task/lcov.py
+++ b/colcon_lcov_result/task/lcov.py
@@ -71,6 +71,8 @@ class LcovCaptureTask(TaskExtensionPoint):
                '--output-file', str(output_file),
                '--config-file', str(self.context.args.lcov_config_file)]
         cmd.extend(additional_args)
+        if args.lcov_args:
+            cmd.extend(args.lcov_args)
 
         rc = await run(
             self.context,

--- a/colcon_lcov_result/verb/lcov_result.py
+++ b/colcon_lcov_result/verb/lcov_result.py
@@ -76,6 +76,12 @@ class LcovResultVerb(VerbExtensionPoint):
             nargs='*',
             help='Remove files matching FILTER from total coverage (e.g. "*/test/*")'
         )
+        parser.add_argument(
+            '--lcov-args',
+            nargs='*',
+            help='Additional arguments to pass to lcov'
+        )
+
         add_packages_arguments(parser)
         add_log_level_argument(parser)
         add_executor_arguments(parser)


### PR DESCRIPTION
## Purpose

This PR adds support for a new `lcov_args` argument. This allows users of `colcon-lcov-result` to pass through any additional command line options to the underlying `lcov` call.

## Context
After moving a ROS 2 stack over to `jazzy`, I found that `colcon lcov-result` was not working quite properly. Without any modification, I was finding zero output in `coverage.info`. After some digging, it looks like the problem may be that `lcov` was exiting early on encountering errors. Specifically, I found that adding `--ignore-errors mismatch` allowed the underlying `lcov` call to work as expected (I think `--keep-going` would work too).

Though this PR doesn't address the root cause of the issue, it at least provides users a way to add custom args easily.

## Alternative implementations
I considered adding a more structured argument, perhaps something like `--ignore-errors` to `colcon lcov-result`. I wanted to get a bit of feedback before implementing that, though, and the current patch was simple enough to put up as a PR.